### PR TITLE
Added a makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ scripts/buildRun.sh
 build/*
 
 !build/.gitkeep
+user.mk

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -82,3 +82,20 @@ target:
 ```sh
 make clean
 ```
+
+To test the ROM with the bgb emulator, use the utility run target:
+```sh
+make run  # NOTE: this will rebuild the rom if any changes have been made
+```
+
+## The `user.mk` file
+
+This file is not tracked by git and is to contain user-specific overrides for
+the makefile. The Makefile includes this file (if it exists) after the
+variables have been set. See the Makefile for possible variables to override.
+
+If your RGBDS toolchain is not in your PATH, you can specify the
+location of each tool manually in this file.
+
+You can also specify a different location for the build directory (BUILD_DIR).
+The directory must exist when building.

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -58,3 +58,27 @@ In the **Cygwin terminal**, enter these commands:
 To build:
 
 	./scripts/build.sh
+
+# Using the Makefile
+
+Note: rgbds must be installed and in your PATH
+
+The provided makefile is an alternative to the build script. Using make allows
+for incremental builds as opposed to rebuilding everything. The makefile should
+work with any system that has GNU Make installed (windows users will need to
+install a port or use mingw).
+
+Just run the make command in the top directory of the source tree
+```sh
+make
+```
+
+The default target is build/game.gb. When adding new assembly files, add its
+corresponding object file to the `OBJ_FILES` variable. The Makefile will only
+build these files.
+
+The build directory can be cleaned (for a complete rebuild) using the clean
+target:
+```sh
+make clean
+```

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ RGBLINK := rgblink
 RGBFIX := rgbfix
 RGBGFX := rgbgfx
 
+#
+# BGB emulator
+#
+BGB := bgb
+
 ASM_FLAGS :=
 LINK_FLAGS := -d -p 0xCB -m $(ROM_MAP) -n $(ROM_SYM)
 FIX_FLAGS := -C -f lhg -i "$(ROM_ID)" -j -k 00 -m 0x1B -n 0x02 -r 0x04 -t "$(ROM_TITLE)" -p 0xCB
@@ -153,6 +158,12 @@ $(OBJ_DIRS):
 #
 clean:
 	find "$(BUILD_DIR)" ! -name .gitkeep ! -path $(BUILD_DIR) -delete
+
+run: $(ROM_GB)
+	@echo "RUN      $(ROM_GB)"
+	@$(BGB) $(ROM_GB)
+
+.PHONY: all clean run
 
 #
 # Keep these files for debugging

--- a/Makefile
+++ b/Makefile
@@ -50,45 +50,11 @@ FIX_FLAGS := -C -f lhg -i "$(ROM_ID)" -j -k 00 -m 0x1B -n 0x02 -r 0x04 -t "$(ROM
 # or a different build directory can be used by overriding BUILD_DIR
 -include user.mk
 
-#
-# List of object files to build, when adding a new assembly file, add its
-# object file here (preferably in alphabetical order).
-# Note: globbing could be used, but I do not recommend it for various reasons
-#       (speed, excluding files is a pain, etc)
-#
-OBJ_FILES := Core/Banks/Banks.obj \
-             Core/Data/Data.obj \
-             Core/DMA/DMA.obj \
-             Core/Graphics/Graphics.obj \
-             Core/InterruptHandlers/HBlank.obj \
-             Core/InterruptHandlers/Joypad.obj \
-             Core/InterruptHandlers/LCDC.obj \
-             Core/InterruptHandlers/LYC.obj \
-             Core/InterruptHandlers/Serial.obj \
-             Core/InterruptHandlers/Timer.obj \
-             Core/InterruptHandlers/VBlank.obj \
-             Core/Joypad/Joypad.obj \
-             Core/MBC/MBC.obj \
-             Core/Memory/Memory.obj \
-             Core/GameLoop.obj \
-             Core/RSTHandlers.obj \
-             Core/Start.obj \
-             Data/Tilemaps/Blank/Blank.tilemap.obj \
-             Data/Tilemaps/Hotel/Hotel.tileset.obj \
-             Data/Tilemaps/Main/Main.tilemap.obj \
-             Data/Tilesets/Font/Font.tileset.obj \
-             Data/Tilesets/Hotel/Hotel.tileset.obj \
-             Data/StringTable.obj \
-             Fixed/Entry.obj \
-             Fixed/Header.obj \
-             Fixed/Interrupts.obj \
-             Fixed/RST.obj \
-             Structure/HRAM.obj \
-             Structure/ROM.obj \
-             Structure/SRAM.obj \
-             Structure/VRAM.obj \
-             Structure/WRAM.obj
-OBJ_FILES := $(addprefix $(BUILD_DIR)/,$(OBJ_FILES))
+# Find the source files to build
+SRC_FILES := $(shell find $(SRC_DIR) -name "*.asm" -or -name "*.z80")
+OBJ_FILES := $(patsubst $(SRC_DIR)/%.asm,$(BUILD_DIR)/%.obj,$(SRC_FILES))
+
+TILES := $(patsubst $(SRC_DIR)/%.png,$(BUILD_DIR)/%.png.2bpp,$(shell find $(SRC_DIR) -name "*.png"))
 
 # dependency files to be created by the assembler
 # not currently used due to the way files are include'd currently
@@ -118,17 +84,16 @@ define ASSEMBLE_RULE
 endef
 #	@$(RGBASM) $(ASM_FLAGS) -M $(BUILD_DIR)/$*.d -o $@ $<
 
-
 #
 # Pattern rule for assembly source to an object file
 #
-$(BUILD_DIR)/%.obj: $(SRC_DIR)/%.asm $(MAKEFILE_LIST)
+$(BUILD_DIR)/%.obj: $(SRC_DIR)/%.asm $(TILES) $(MAKEFILE_LIST)
 	$(ASSEMBLE_RULE)
 
 #
 # Same as above except for *.z80 files
 #
-$(BUILD_DIR)/%.obj: $(SRC_DIR)/%.z80 $(MAKEFILE_LIST)
+$(BUILD_DIR)/%.obj: $(SRC_DIR)/%.z80 $(TILES) $(MAKEFILE_LIST)
 	$(ASSEMBLE_RULE)
 
 #
@@ -168,7 +133,7 @@ run: $(ROM_GB)
 #
 # Keep these files for debugging
 #
-.PRECIOUS: $(ROM_MAP) $(ROM_SYM)
+.PRECIOUS: $(ROM_MAP) $(ROM_SYM) $(TILES)
 
 # -----------------------------------------------------------------------------
 # EXTRA DEPENDENCIES
@@ -176,9 +141,9 @@ run: $(ROM_GB)
 #
 # Tile dependencies
 #
-$(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.obj: $(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.png.2bpp
+#$(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.obj: $(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.png.2bpp
 
-$(BUILD_DIR)/Data/Tilesets/Hotel/Hotel.tileset.obj: $(BUILD_DIR)/Data/Tilesets/Hotel/Hotel.tileset.png.2bpp
+#$(BUILD_DIR)/Data/Tilesets/Hotel/Hotel.tileset.obj: $(BUILD_DIR)/Data/Tilesets/Hotel/Hotel.tileset.png.2bpp
 
 #
 # assembler-generated dependency files

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,136 @@
+#
+# Makefile for building the ROM, as an alternative to scripts/build.sh
+#
+
+# some important paths (no trailing slash)
+BUILD_DIR := build
+SRC_DIR := src
+
+# name of the ROM file
+PROJECT_NAME := game
+
+ROM_GB := $(BUILD_DIR)/$(PROJECT_NAME).gb
+ROM_MAP := $(BUILD_DIR)/$(PROJECT_NAME).map
+ROM_SYM := $(BUILD_DIR)/$(PROJECT_NAME).sym
+
+#
+# Variables for the RGB toolchain (just the command name if you have PATH set)
+#
+RGBASM := rgbasm
+RGBLINK := rgblink
+RGBFIX := rgbfix
+RGBGFX := rgbgfx
+
+ASM_FLAGS :=
+LINK_FLAGS := -d -p 0xFF -m $(ROM_MAP) -n $(ROM_SYM)
+FIX_FLAGS := -c -f lhg -i PROJ -j -k 00 -m 0x10 -n 0x00 -r 0x03 -t "BOILERPLATEPROJ" -p 0xFF
+
+#
+# List of object files to build, when adding a new assembly file, add its
+# object file here (preferably in alphabetical order).
+# Note: globbing could be used, but I do not recommend it for various reasons
+#       (speed, excluding files is a pain, etc)
+#
+OBJ_FILES := Core/Banks/Banks.obj \
+             Core/Data/Data.obj \
+             Core/DMA/DMA.obj \
+             Core/Graphics/Graphics.obj \
+             Core/InterruptHandlers/HBlank.obj \
+             Core/InterruptHandlers/Joypad.obj \
+             Core/InterruptHandlers/LCDC.obj \
+             Core/InterruptHandlers/LYC.obj \
+             Core/InterruptHandlers/Serial.obj \
+             Core/InterruptHandlers/Timer.obj \
+             Core/InterruptHandlers/VBlank.obj \
+             Core/Joypad/Joypad.obj \
+             Core/MBC/MBC.obj \
+             Core/Boot.obj \
+             Core/GameLoop.obj \
+             Core/Memory.obj \
+             Core/RSTHandlers.obj \
+             Core/Start.obj \
+             Data/Tilemaps/Main.tilemap.obj \
+             Data/Tilesets/Font/Font.tileset.obj \
+             Data/StringTable.obj \
+             Fixed/Entry.obj \
+             Fixed/Header.obj \
+             Fixed/Interrupts.obj \
+             Fixed/RST.obj \
+             Structure/HRAM.obj \
+             Structure/ROM.obj \
+             Structure/SRAM.obj \
+             Structure/VRAM.obj \
+             Structure/WRAM.obj
+OBJ_FILES := $(addprefix $(BUILD_DIR)/,$(OBJ_FILES))
+
+#
+# default target is the ROM file
+#
+all: $(ROM_GB)
+
+# =============================================================================
+# Rule for automatically creating directories in the build dir
+#
+# To use: add $(MARKER) as a dependency to a target so that make will create
+# the directory (if needed) that the target will reside in
+
+
+.SECONDEXPANSION:
+
+MARKER_FILE := .marker
+
+MARKER = $$(@D)/$(MARKER_FILE)
+
+%/$(MARKER_FILE):
+	@echo "    [MKDIR] $(dir $@)"
+	@mkdir -p $(dir $@)
+	@touch $@
+
+# =============================================================================
+
+#
+# this is a little jank but it should work for now
+# (TODO: maybe have the %.obj rules have all 2bpp targets as a dependency)
+#
+$(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.obj: $(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.png.2bpp
+
+#
+# Pattern rule for assembly source to an object file
+#
+$(BUILD_DIR)/%.obj: $(SRC_DIR)/%.asm $(MARKER)
+	@echo "    [ASM]  $@"
+	@$(RGBASM) $(ASM_FLAGS) -o $@ $<
+
+#
+# Same as above except for *.z80 files
+#
+$(BUILD_DIR)/%.obj: $(SRC_DIR)/%.z80 $(MARKER)
+	@echo "    [ASM]  $@"
+	@$(RGBASM) $(ASM_FLAGS) -o $@ $<
+
+#
+# Pattern rule for png images to planar tile format
+# (Note: I removed the '-f' option from the build script)
+#
+$(BUILD_DIR)/%.png.2bpp: $(SRC_DIR)/%.png $(MARKER)
+	@echo "    [GFX]  $@"
+	@$(RGBGFX) -o $@ $<
+
+$(ROM_GB): $(OBJ_FILES)
+	@echo "    [LINK] $@"
+	@$(RGBLINK) $(LINK_FLAGS) -o $@ $+
+	@echo "    [FIX]  $@"
+	@$(RGBFIX) $(FIX_FLAGS) $@
+
+#
+# Clean will delete everything in the build directory except for:
+#    - .gitkeep
+#    - $(BUILD_DIR) itself
+#
+clean:
+	find "$(BUILD_DIR)" \\! -name .gitkeep \\! -path $(BUILD_DIR) -delete
+
+#
+# Keep these files for debugging
+#
+.PRECIOUS: $(ROM_MAP) $(ROM_SYM) %/$(MARKER_FILE)

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,13 @@ OBJ_FILES := Core/Banks/Banks.obj \
              Structure/WRAM.obj
 OBJ_FILES := $(addprefix $(BUILD_DIR)/,$(OBJ_FILES))
 
+# dependency files to be created by the assembler
+# not currently used due to the way files are include'd currently
+# NOTE: this actually stalls the build due to repeated includes, some .d files
+# end up being ~200 lines long due to no guards on src/Includes.inc and a
+# possible bug with RGBASM (duplicate entries)
+#OBJ_DEPS := $(OBJ_FILES:.obj=.d)
+
 # get a list of all directories that will need to be created when building
 # patsubst removes the trailing slash
 # (for some reason if this was left in, make would always remake the directories)
@@ -102,6 +109,8 @@ define ASSEMBLE_RULE
 	@echo "ASM      $@"
 	@$(RGBASM) $(ASM_FLAGS) -o $@ $<
 endef
+#	@$(RGBASM) $(ASM_FLAGS) -M $(BUILD_DIR)/$*.d -o $@ $<
+
 
 #
 # Pattern rule for assembly source to an object file
@@ -156,3 +165,8 @@ clean:
 #
 $(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.obj: $(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.png.2bpp
 
+#
+# assembler-generated dependency files
+# NOT USED
+#
+#-include $(OBJ_DEPS)

--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ $(OBJ_DIRS):
 #    - $(BUILD_DIR) itself
 #
 clean:
-	find "$(BUILD_DIR)" \\! -name .gitkeep \\! -path $(BUILD_DIR) -delete
+	find "$(BUILD_DIR)" ! -name .gitkeep ! -path $(BUILD_DIR) -delete
 
 #
 # Keep these files for debugging

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ RGBFIX := rgbfix
 RGBGFX := rgbgfx
 
 ASM_FLAGS :=
-LINK_FLAGS := -d -p 0xFF -m $(ROM_MAP) -n $(ROM_SYM)
-FIX_FLAGS := -c -f lhg -i "$(ROM_ID)" -j -k 00 -m 0x10 -n 0x00 -r 0x03 -t "$(ROM_TITLE)" -p 0xFF
+LINK_FLAGS := -d -p 0xCB -m $(ROM_MAP) -n $(ROM_SYM)
+FIX_FLAGS := -C -f lhg -i "$(ROM_ID)" -j -k 00 -m 0x1B -n 0x02 -r 0x04 -t "$(ROM_TITLE)" -p 0xCB
 
 # (optional) user-specific overrides
 # this can be used to specify the location of the RGBDS toolchain manually
@@ -64,13 +64,15 @@ OBJ_FILES := Core/Banks/Banks.obj \
              Core/InterruptHandlers/VBlank.obj \
              Core/Joypad/Joypad.obj \
              Core/MBC/MBC.obj \
-             Core/Boot.obj \
+             Core/Memory/Memory.obj \
              Core/GameLoop.obj \
-             Core/Memory.obj \
              Core/RSTHandlers.obj \
              Core/Start.obj \
-             Data/Tilemaps/Main.tilemap.obj \
+             Data/Tilemaps/Blank/Blank.tilemap.obj \
+             Data/Tilemaps/Hotel/Hotel.tileset.obj \
+             Data/Tilemaps/Main/Main.tilemap.obj \
              Data/Tilesets/Font/Font.tileset.obj \
+             Data/Tilesets/Hotel/Hotel.tileset.obj \
              Data/StringTable.obj \
              Fixed/Entry.obj \
              Fixed/Header.obj \
@@ -164,6 +166,8 @@ clean:
 # Tile dependencies
 #
 $(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.obj: $(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.png.2bpp
+
+$(BUILD_DIR)/Data/Tilesets/Hotel/Hotel.tileset.obj: $(BUILD_DIR)/Data/Tilesets/Hotel/Hotel.tileset.png.2bpp
 
 #
 # assembler-generated dependency files

--- a/Makefile
+++ b/Makefile
@@ -98,19 +98,22 @@ OBJ_DIRS := $(patsubst %/,%,$(sort $(dir $(OBJ_FILES))))
 #
 all: $(ROM_GB)
 
+define ASSEMBLE_RULE
+	@echo "ASM      $@"
+	@$(RGBASM) $(ASM_FLAGS) -o $@ $<
+endef
+
 #
 # Pattern rule for assembly source to an object file
 #
 $(BUILD_DIR)/%.obj: $(SRC_DIR)/%.asm $(MAKEFILE_LIST)
-	@echo "ASM      $@"
-	@$(RGBASM) $(ASM_FLAGS) -o $@ $<
+	$(ASSEMBLE_RULE)
 
 #
 # Same as above except for *.z80 files
 #
 $(BUILD_DIR)/%.obj: $(SRC_DIR)/%.z80 $(MAKEFILE_LIST)
-	@echo "ASM      $@"
-	@$(RGBASM) $(ASM_FLAGS) -o $@ $<
+	$(ASSEMBLE_RULE)
 
 #
 # Pattern rule for png images to planar tile format

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ OBJ_FILES := Core/Banks/Banks.obj \
              Structure/WRAM.obj
 OBJ_FILES := $(addprefix $(BUILD_DIR)/,$(OBJ_FILES))
 
+# -----------------------------------------------------------------------------
+# RULES
+
 #
 # default target is the ROM file
 #
@@ -82,15 +85,14 @@ MARKER_FILE := .marker
 MARKER = $$(@D)/$(MARKER_FILE)
 
 %/$(MARKER_FILE):
-	@echo "    [MKDIR] $(dir $@)"
+	@echo "MKDIR    $(dir $@)"
 	@mkdir -p $(dir $@)
 	@touch $@
 
 # =============================================================================
 
 #
-# this is a little jank but it should work for now
-# (TODO: maybe have the %.obj rules have all 2bpp targets as a dependency)
+# Tile dependencies
 #
 $(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.obj: $(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.png.2bpp
 
@@ -98,14 +100,14 @@ $(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.obj: $(BUILD_DIR)/Data/Tilesets/Fon
 # Pattern rule for assembly source to an object file
 #
 $(BUILD_DIR)/%.obj: $(SRC_DIR)/%.asm $(MARKER)
-	@echo "    [ASM]  $@"
+	@echo "ASM      $@"
 	@$(RGBASM) $(ASM_FLAGS) -o $@ $<
 
 #
 # Same as above except for *.z80 files
 #
 $(BUILD_DIR)/%.obj: $(SRC_DIR)/%.z80 $(MARKER)
-	@echo "    [ASM]  $@"
+	@echo "ASM      $@"
 	@$(RGBASM) $(ASM_FLAGS) -o $@ $<
 
 #
@@ -113,13 +115,13 @@ $(BUILD_DIR)/%.obj: $(SRC_DIR)/%.z80 $(MARKER)
 # (Note: I removed the '-f' option from the build script)
 #
 $(BUILD_DIR)/%.png.2bpp: $(SRC_DIR)/%.png $(MARKER)
-	@echo "    [GFX]  $@"
+	@echo "GFX      $@"
 	@$(RGBGFX) -o $@ $<
 
 $(ROM_GB): $(OBJ_FILES)
-	@echo "    [LINK] $@"
+	@echo "LINK     $@"
 	@$(RGBLINK) $(LINK_FLAGS) -o $@ $+
-	@echo "    [FIX]  $@"
+	@echo "FIX      $@"
 	@$(RGBFIX) $(FIX_FLAGS) $@
 
 #

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,31 @@
 # Makefile for building the ROM, as an alternative to scripts/build.sh
 #
 
+#------------------------------------------------------------------------------
+# VARIABLES
+
 # some important paths (no trailing slash)
 BUILD_DIR := build
 SRC_DIR := src
 
-# name of the ROM file
-PROJECT_NAME := game
+#
+# ROM file name
+#
+ROM_NAME := game
 
-ROM_GB := $(BUILD_DIR)/$(PROJECT_NAME).gb
-ROM_MAP := $(BUILD_DIR)/$(PROJECT_NAME).map
-ROM_SYM := $(BUILD_DIR)/$(PROJECT_NAME).sym
+#
+# game ID string (must be 4 characters)
+#
+ROM_ID := PROJ
+
+#
+# game title (truncated to 16 characters)
+#
+ROM_TITLE := BOILERPLATEPROJ
+
+ROM_GB := $(BUILD_DIR)/$(ROM_NAME).gb
+ROM_MAP := $(BUILD_DIR)/$(ROM_NAME).map
+ROM_SYM := $(BUILD_DIR)/$(ROM_NAME).sym
 
 #
 # Variables for the RGB toolchain (just the command name if you have PATH set)
@@ -23,7 +38,12 @@ RGBGFX := rgbgfx
 
 ASM_FLAGS :=
 LINK_FLAGS := -d -p 0xFF -m $(ROM_MAP) -n $(ROM_SYM)
-FIX_FLAGS := -c -f lhg -i PROJ -j -k 00 -m 0x10 -n 0x00 -r 0x03 -t "BOILERPLATEPROJ" -p 0xFF
+FIX_FLAGS := -c -f lhg -i "$(ROM_ID)" -j -k 00 -m 0x10 -n 0x00 -r 0x03 -t "$(ROM_TITLE)" -p 0xFF
+
+# (optional) user-specific overrides
+# this can be used to specify the location of the RGBDS toolchain manually
+# or a different build directory can be used by overriding BUILD_DIR
+-include user.mk
 
 #
 # List of object files to build, when adding a new assembly file, add its
@@ -79,11 +99,6 @@ OBJ_DIRS := $(patsubst %/,%,$(sort $(dir $(OBJ_FILES))))
 all: $(ROM_GB)
 
 #
-# Tile dependencies
-#
-$(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.obj: $(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.png.2bpp
-
-#
 # Pattern rule for assembly source to an object file
 #
 $(BUILD_DIR)/%.obj: $(SRC_DIR)/%.asm $(MAKEFILE_LIST)
@@ -129,3 +144,12 @@ clean:
 # Keep these files for debugging
 #
 .PRECIOUS: $(ROM_MAP) $(ROM_SYM)
+
+# -----------------------------------------------------------------------------
+# EXTRA DEPENDENCIES
+
+#
+# Tile dependencies
+#
+$(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.obj: $(BUILD_DIR)/Data/Tilesets/Font/Font.tileset.png.2bpp
+


### PR DESCRIPTION
Not sure if you wanted this, but I added a makefile to your boilerplate. The makefile should build everything the same as the scripts/build.sh script. The only difference is that the makefile does not use globbing. If you add a new source file, you will need to add its object file to the list in the OBJ_FILES variable.

Targets:
 * all: default, builds the ROM
 * clean: removes all files in the build directory (except .gitkeep)
 * run: launches the BGB emulator with the built ROM